### PR TITLE
Fix logging and URL issues

### DIFF
--- a/octoprint_octovox/__init__.py
+++ b/octoprint_octovox/__init__.py
@@ -25,8 +25,10 @@ class OctovoxPlugin(octoprint.plugin.StartupPlugin,
 	def __init__(self):
 		super(OctovoxPlugin, self).__init__()
 		self._updateStatusTimer = None
-		self._update_status = UpdateStatus()
+		self._update_status = None
 
+        def initialize(self):
+		self._update_status = UpdateStatus(self._logger)
 
 	##~~ StartupPlugin mixin
 
@@ -50,9 +52,9 @@ class OctovoxPlugin(octoprint.plugin.StartupPlugin,
 		)
 
         def get_settings_restricted_paths(self):
-		return dict(admin=[["printer_name"], ["printer_uid"], ["printer_is_registered"], ["printer_last_update_result"], ["update_settings_interval"],],
+		return dict(admin=[["printer_name"], ["printer_uid"], ["printer_is_registered"], ["printer_last_update_result"], ["update_settings_interval"], ["baseApiUrl"], ["baseRegistrationUrl"], ["registration_client_key"],],
                 		user=[[],],
-                		never=[["baseApiUrl"], ["baseRegistrationUrl"], ["registration_client_key"],])
+                		never=[[],])
 
 	def on_settings_save(self, data):
         	self._logger.info("saving settings")

--- a/octoprint_octovox/update_status.py
+++ b/octoprint_octovox/update_status.py
@@ -6,7 +6,7 @@ from octoprint.events import Events
 
 class UpdateStatus:
 
-	def __init__(self):
+	def __init__(self, logger):
 		self._statusItemIds = {
 			'hotend_temp': 1,
 			'bed_temp': 2,
@@ -18,6 +18,7 @@ class UpdateStatus:
 			'last_print_time': 8,
 			'last_print_result': 9
 		}
+		self._logger = logger
 		self._previousJobResult = ""
 		self._failureCount = 0
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octovox"
 plugin_name = "OctoPrint-OctoVox"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.4"
+plugin_version = "0.1.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Foosel correctly pointed out that I had broken the plugin by leaving the logger undefined. This resolves that issue.

Also, tagging the URL paths in the Settings API with "never" in the restricted paths caused issues with the Knockout JS retrievals.