### PR TITLE
Add Italian translation

### DIFF
--- a/skill_translations/AlexaIntentStrings.json
+++ b/skill_translations/AlexaIntentStrings.json
@@ -499,11 +499,19 @@
 					},
 					{
 						"name": "AMAZON.CancelIntent",
-						"samples": []
+						"samples": [
+							"Cancella stampa",
+							"Interrompi stampa"
+						]
 					},
 					{
 						"name": "AMAZON.HelpIntent",
-						"samples": []
+						"samples": [
+							"Aiuto",
+							"Help",
+							"Non funziona",
+							"Cosa devo fare"
+						]
 					},
 					{
 						"name": "AMAZON.StopIntent",
@@ -511,25 +519,31 @@
 					},
 					{
 						"name": "AMAZON.NavigateHomeIntent",
-						"samples": []
+						"samples": [
+							"Torna al menu principale"
+						]
 					},
 					{
 						"name": "GetStatusIntent",
 						"slots": [],
 						"samples": [
-							"chiedi il mio server di stampa di tre d.",
-							"chiedi ai miei tre servizi di stampa per un aggiornamento dello stato",
-							"chiedi un aggiornamento al mio tre d. print server",
-							"chiedi al mio server di stampa d tre cosa stampa",
-							"chiedi al mio server di stampa d tre per lo stato della mia stampante",
-							"aggiornare",
+							"chiedi al mio server di stampa tre d.",
+							"chiedi al mio server di stampa un aggiornamento dello stato",
+							"chiedi un aggiornamento al mio server di stampa tre d",
+							"chiedi al mio server di stampa tre d cosa stampa",
+							"chiedi al mio server di stampa tre d lo stato della mia stampante", // connected with HelpMessage and HelpMessageGoogle
+							"aggiornami.",
 							"stato",
 							"qual è lo stato della mia stampante.",
-							"dammi un aggiornamento sul mio stato.",
+							"dammi un aggiornamento sullo stato",
 							"dammi un aggiornamento.",
-							"ciò che sta attualmente stampando.",
-							"qual è lo stato della mia stampante.",
-							"qual è il mio status"
+							"ciò che sta attualmente stampando",
+							"qual è lo stato della mia stampante",
+							"qual è il mio status",
+							"quanto manca",
+							"manca ancora molto",
+							"a che punto è la stampante",
+							"a che punto è la stampa tre d"
 						]
 					},
 					{
@@ -537,8 +551,8 @@
 						"slots": [],
 						"samples": [
 							"esempio",
-							"risposta del campione",
-							"campione",
+							"esempi",
+							"esempio di intento",
 							"Demo"
 						]
 					},
@@ -546,19 +560,23 @@
 						"name": "GetTempIntent",
 						"slots": [],
 						"samples": [
-							"chiedi la temperatura del mio server di stampa d tre",
-							"chiedi la mia stampa di tre d. per la sua temperatura",
-							"chiedi al mio server di stampa d tre per la temperatura",
+							"chiedi la temperatura del mio server di stampa tre d",
+							"chiedi la temperatura alla stampa tre d",
+							"chiedi la temperatura al mio server di stampa tre d",
 							"chiedi al mio tre server di stampa qual è la temperatura della stampante",
-							"chiedi al mio server di stampa d tre la temperatura della mia stampante",
+							"chiedi al mio server di stampa tre d la temperatura della mia stampante",
 							"temperatura",
 							"Temp",
-							"qual è la temperatura della mia stampante.",
-							"dammi la temp.",
+							"dammi temperatura.",
 							"dammi la temperatura.",
-							"qual è la temperatura attuale.",
-							"qual è la temperatura della mia stampante.",
-							"qual è il mio temp."
+							"dammi le temperature.",
+							"leggi tempertura.",
+							"aggiornami sulle temperature",
+							"qual è la temperatura della mia stampante",
+							"quali sono le temperature della mia stampante",
+							"qual è la temperatura della stampante",
+							"qual è la temperatura attuale",
+							"qual è temp"
 						]
 					},
 					{
@@ -566,20 +584,41 @@
 						"slots": [],
 						"samples": [
 							"chiedi al mio server di stampa tre d. tempo rimanente",
-							"chiedi al mio server di stampa d tre quanto tempo rimane",
-							"chiedi al mio tre d. print server per quanto tempo",
+							"chiedi al mio server di stampa tre d quanto tempo rimane",
+							"chiedi al mio server di stampa tre d quanto tempo manca",
+							"chiedi al mio server tre d. print quanto tempo",
 							"tempo",
-							"quanto tempo è rimasto.",
-							"quanto tempo rimane."
+							"quanto tempo è rimasto",
+							"quanto tempo rimane",
+							"quanto tempo manca alla fine della stampa",
+							"quanto tempo manca alla fine",
+							"quanto tempo manca"
 						]
 					},
 					{
 						"name": "AMAZON.PauseIntent",
-						"samples": []
+						"samples": [
+							"pausa la stampa tre d",
+							"ferma la stampa tre d",
+							"pausa la stampa",
+							"smetti di stampare",
+							"ferma la stampa",
+							"fermati",
+							"pausa"
+						]
 					},
 					{
 						"name": "AMAZON.ResumeIntent",
-						"samples": []
+						"samples": [
+							"riprendi la stampa tre d",
+							"continua la stampa tre d",
+							"riprendi a stampare",
+							"continua a stampare",
+							"riprendi la stampa",
+							"continua la stampa",
+							"finisci la pausa",
+							"smetti la pausa"
+						]
 					}
 				],
 				"types": []

--- a/skill_translations/AlexaSkillResponseStrings.json
+++ b/skill_translations/AlexaSkillResponseStrings.json
@@ -165,7 +165,56 @@
     },
     "it-IT": {
       "Static": {
-        "WelcomeSsml": "Benvenuti a <sub alias=\"Octo Vox\">OctoVox</sub>! Come posso aiutarla?"
+        "WelcomeSsml": "Benvenuti a <sub alias=\"Octo Vox\">OctoVox</sub>! Come posso aiutarla?",
+        "Demo1": "Ecco una risposta di esempio: La tua stampante 3D sta stampando. La temperatura della testina di stampa è 220.0 gradi. La temperatura del letto di stampa è 60.1 gradi. Il job di stampa corrente è Spool_Holder_15_millimeter<sub alias=\"dot gee code\">.gcode</sub>. Il  The current job is 25 percent complete. The estimated time remaining is 3 hours, 20 minutes, 14 seconds.",
+        "Demo2": "Here is a sample response: Your Printer is currently Idle. The Hot End Temperature is 72.0 degrees. The Bed Temperature is 27.5 degrees. The previous job Spool_Holder_15_millimeter<sub alias=\"dot gee code\">.gcode</sub> completed in 3 hours, 20 minutes, 14 seconds.",
+        "HelpMessage": "Con lo skill <sub alias=\"Octo Vox\">OctoVox</sub> puoi avere informazione riguardo le stampanti 3-D connesse a OctoPrint dal tuo Amazon Echo. Puoi dire cose come: chiedi al mio server di stampa 3-D lo stato della mia stampante, or, chiedi al mio server 3-D cosa sta stampando. Puoi anche chiedergli, \"Demo\", per sentire risposte di esempio.",
+        "HelpAccountLink": "Quresto skill richiederà di create e collegare un account per usare la maggior parte delle features. Abbiamo inviato una richiesta LinkAccount all'Alexa App. È necessario che tu vada all'App Alexa per confermare questo collegamento al tuo account.",
+        "Prompt": "Cosa vorresti fare adesso?",
+        "HelpPrompt": "come posso aiutarti?",
+        "Goodbye": "Grazie per aver usato <sub alias=\"Octo Vox\">OctoVox.</sub>.",
+        "Fallback": "Purtroppo non ho capito bene cosa chiedevi, forse non sono sufficientemente istruita, sai che puoi istruirmi anche tu in https://github.com/johnnyruz/OctoPrint-OctoVox/issues/5. Comunque per ora assumo tu mi abbia chiesto lo stato della stampante.",
+        "AccountLinkWelcome": "Benvenuto nel servizio <sub alias=\"Octo Vox\">OctoVox</sub>! Questo skill richiede collegamento dell'account. Abbiamo inviato una richiesta LinkAccount alla tua App Alexa. È necessario che tu apra la App Alexa per confermare il collegamento al tuo account. Puoi anche dire, \"Aiuto\", per maggiori informazioni. Cosa vuoi fare?",
+        "AccountLink": "Questo skill richiede collegamento con il tuo account linking. Abbiamo spedito una richiesta alla tua App Alexa. È necessario che tu vada all'App Alexa per impostare il tuo account.  Puoi anche dire, \"Aiuto\", per maggiori informazioni.",
+        "HelpMessageGoogle": "Con OctoVox puoi chiedere informationi riguardo la tua stampante 3D connessa a OctoPrint dal tuo dispositivo Google Home.  Puoi dire cose come: chiedi al mio server di stampa 3-D lo stato della mia stampante, or, chiedi al mio server 3-D cosa sta stampando. Puoi anche chiedergli, \"Demo\", per sentire risposte di esempio.",
+        "HelpMessageLinkGoogle": "Per poter usare OctoVox, dovrai collegare il tuo account OctoVox con Google. Puoi dire \"Collega account\" o perlomeno \"Link Account\", per cominciare il procedimento di collegamento. Puoi anche dire, \"Help\", per maggiori informazioni.",
+        "AccountLinkGoogle": "Sembra che tu non abbia ancora collegato il tuo account OctoVox con Google.  Per farlo dì \"Collega account\" o \"Link Account\", in modo tale da cominciare il procedimento di collegamento. Puoi anche dire, \"Help\", per maggiori informazioni",
+        "AccountLinkGoogleReprompt": "Dì \"Link Account\" per continuare con il collegamento dell'account",
+        "StopString": "Grazie per aver usato OctoVox!"
+      },
+      "Measure": {
+        "Test": "TestMeasure {0}",
+        "HotEndTemp": "La temperatura dell'augello di stampa è {0} gradi.",
+        "BedTemp": "La temperatura della base di stampa è {0} gradis.",
+        "PrinterState": "{0} è {1}.",
+        "CompletionPercent": "Il lavoro di stampa è {0} percento completo.",
+        "TimeRemaining": "La stima del tempo restante è {0}.",
+        "CurrentZ": "La currente posizione Z e` {0} millimetri.",
+        "Filename": "Il file in stampa è {0}.",
+        "LastJobResultSuccess": "Il precedente job {0} completed in {1}.",
+        "LastJobResultFailure": "Il precedente job {0} è fallito perché {1}."
+      },
+      "Error": {
+        "ResponseError": "{0} non risponde correttamente.",
+        "NoUpdateError": "{0} non ha ripostato lo stato per più di {1} {2}. Si raccomanda di controlla la configurazione.",
+        "NoStatusError": "{0} non è in uno stato di funzionamento conosciuto.",
+        "UnknownHotEnd": "La temperatura dell'augello di stampa è sconosciuto.",
+        "UnknownBed": "La temperatura della base di stampa è sconosciuta.",
+        "UnknownFile": "Il file corrente è sconosciuto.",
+        "UnknownPercentage": "La percentuale di lavoro compiuto è sconosciuta.",
+        "UnknownEta": "Il tempo restante è sconosciuto.",
+        "RequestValidationFailed": "Impossibile Validare Richiesta",
+        "NoRegisteredPrinters": "Non hai alcuna stampante registrata"
+      },
+      "Time": {
+        "Day": "giorno",
+        "Days": "giorni",
+        "Hour": "ora",
+        "Hours": "ore",
+        "Minute": "minuto",
+        "Minutes": "minuti",
+        "Second": "secondo",
+        "Seconds": "secondi"
       }
     },
     "ja-JP": {


### PR DESCRIPTION
Doubts:
- google "link account", is it translated in Italian by google with
 "collega account"? (as I assumed, apparently I didn't find how google
 translated it in Italian and I don't have the device "google home")
- see in the note below, I had the idea to make the Fallback answer
 pointing to github, is that ok?

Note:
The list of samples is actually possibly incomplete,
other translators might add more samples, particularly some
combinations of synonyms might be missing
I put Fallback a response with a link to github
https://github.com/johnnyruz/OctoPrint-OctoVox/issues/5

I had a look at Amazon suggestion on how to write samples here:
https://developer.amazon.com/docs/custom-skills/best-practices-for-sample-utterances-and-custom-slot-type-values.html#it-it1
Even though this link should go in README.md as guideline
for all translations